### PR TITLE
Swap typography-js paths if user defines one

### DIFF
--- a/themes/gatsby-theme-blog/gatsby-config.js
+++ b/themes/gatsby-theme-blog/gatsby-config.js
@@ -1,4 +1,5 @@
 const path = require('path')
+const withThemePath = require('./with-theme-path')
 
 module.exports = ({ root }) => ({
   siteMetadata: {
@@ -64,10 +65,7 @@ module.exports = ({ root }) => ({
     {
       resolve: 'gatsby-plugin-typography',
       options: {
-        pathToConfigModule: path.relative(
-          root,
-          require.resolve('./src/utils/typography')
-        ),
+        pathToConfigModule: withThemePath('./src/utils/typography'),
       },
     },
     {

--- a/ui-surfaces/blog-a/src/utils/typography.js
+++ b/ui-surfaces/blog-a/src/utils/typography.js
@@ -1,0 +1,77 @@
+import Typography from "typography";
+import gray from "gray-percentage";
+
+const MyTheme = {
+  title: "MyTheme",
+  baseFontSize: "12px",
+  baseLineHeight: 1.4,
+  headerFontFamily: ["Lucida Grande", "Verdana", "Arial", "Sans-Serif"],
+  bodyFontFamily: ["Lucida Grande", "Verdana", "Arial", "Sans-Serif"],
+  bodyColor: "hsla(0,0%,0%,0.8)",
+  headerWeight: "bold",
+  bodyWeight: "normal",
+  boldWeight: "bold",
+  overrideStyles: ({ rhythm }) => ({
+    h2: {
+      marginTop: rhythm(2)
+    },
+    h3: {
+      marginTop: rhythm(2)
+    },
+    p: {
+      marginBottom: "1em",
+      marginTop: "1em"
+    },
+    ol: {
+      marginBottom: 0,
+      marginLeft: rhythm(2.125)
+    },
+    ul: {
+      listStyle: "none",
+      marginLeft: 0,
+      paddingLeft: rhythm(5 / 8),
+      textIndent: rhythm(-5 / 8)
+    },
+    li: {
+      display: "list-item",
+      marginLeft: rhythm(5 / 8)
+    },
+    "ul li:before": {
+      content: '"» "'
+    },
+    a: {
+      color: "#06c",
+      textDecoration: "none"
+    },
+    "a:hover": {
+      color: "#147",
+      textDecoration: "underline"
+    },
+    "a:visited": {
+      color: "#b85b5a"
+    },
+    blockquote: {
+      color: gray(47),
+      marginTop: rhythm(1),
+      marginRight: rhythm(2),
+      marginBottom: 0,
+      marginLeft: rhythm(5 / 8),
+      paddingLeft: rhythm(1.25),
+      borderLeft: `${rhythm(1 / 3)} solid ${gray(87)}`
+    },
+    "a.gatsby-resp-image-link": {
+      boxShadow: "none"
+    }
+  })
+};
+
+const typography = new Typography(MyTheme);
+
+// Hot reload typography in development.
+if (process.env.NODE_ENV !== "production") {
+  typography.injectStyles();
+}
+
+export default typography;
+export const rhythm = typography.rhythm;
+export const scale = typography.scale;


### PR DESCRIPTION
Use the `withThemePath` helper to replace the require'd typography util path with the user's if they defined one.

Can't merge because it requires the following diff to gatsby-plugin-typography, which hasn't been merged yet.

```diff
diff --git a/packages/gatsby-plugin-typography/src/gatsby-node.js b/packages/gatsby-plugin-typography/src/gatsby-node.js
index 12b90c478..260c77146 100644
--- a/packages/gatsby-plugin-typography/src/gatsby-node.js
+++ b/packages/gatsby-plugin-typography/src/gatsby-node.js
@@ -5,14 +5,14 @@ const os = require(`os`)
 // Write out a typography module to .cache.

 exports.onPreBootstrap = ({ store }, pluginOptions) => {
-  const program = store.getState().program
-
   let module
   if (pluginOptions.pathToConfigModule) {
-    module = `module.exports = require("${path.join(
-      program.directory,
-      pluginOptions.pathToConfigModule
-    )}")`
+    module = `module.exports = require("${
+      path.isAbsolute(pluginOptions.pathToConfigModule)
+        ? console.log("isAbsolute") || pluginOptions.pathToConfigModule
+        : console.log("isRelative") ||
+          path.join(program.directory, pluginOptions.pathToConfigModule)
+    }")`
     if (os.platform() == `win32`) {
       module = module.split(`\\`).join(`\\\\`)
     }
@@ -22,11 +22,11 @@ const typography = new Typography()
 module.exports = typography`
   }

-  const dir = `${__dirname}/.cache`
+  const dir = `${store.getState().program.directory}/.cache`

   if (!fs.existsSync(dir)) {
     fs.mkdirSync(dir)
   }
-
+  console.log("typography ::::::::: ", module)
   fs.writeFileSync(`${dir}/typography.js`, module)
 }
```