### PR TITLE
Component shadowing

### DIFF
--- a/themes/gatsby-theme-docz/package.json
+++ b/themes/gatsby-theme-docz/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "gatsby-docz",
-  "version": "1.0.0",
+  "name": "gatsby-theme-docz",
+  "version": "0.0.1",
   "main": "index.js",
   "author": "christopherbiscardi <chris@christopherbiscardi.com> (@chrisbiscardi)",
   "license": "MIT"

--- a/ui-surfaces/blog-a/src/components/gatsby-theme-blog/Bio.js
+++ b/ui-surfaces/blog-a/src/components/gatsby-theme-blog/Bio.js
@@ -1,0 +1,2 @@
+import React from "react";
+export default () => <div>Component Shadowing the Bio component</div>;


### PR DESCRIPTION
Example usage of Component Shadowing

We should remove the userland implementation from the repo as well

This example is boring.af, because it's just creating a new file which shadows the old file. The interesting bits with be in the gatsby PR.